### PR TITLE
Add rustc flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+*
+!/conda-forge.yml
+
+!/*/
+!/recipe/**
+!/.ci_support/**
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -71,7 +71,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance

--- a/recipe/install_scripts.sh
+++ b/recipe/install_scripts.sh
@@ -3,8 +3,10 @@ mkdir -p "${PREFIX}"/etc/conda/{de,}activate.d/
 if [[ "${family}" == "x86_64" ]]; then
   if [[ "${level}" == "1" ]]; then
     flag="-march=x86-64"
+    rust_target_cpu="-C target-cpu=x86-64"
   else
     flag="-march=x86-64-v${level}"
+    rust_target_cpu="-C target-cpu=x86-64-v${level}"
   fi
 elif [[ "${family}" == "ppc64le" ]]; then
   flag="-mcpu=power${level}"
@@ -14,4 +16,5 @@ cat << EOF > "${PREFIX}/etc/conda/activate.d/~activate-${family}-level.sh"
 export CXXFLAGS="\${CXXFLAGS} ${flag}"
 export CFLAGS="\${CFLAGS} ${flag}"
 export CPPFLAGS="\${CPPFLAGS} ${flag}"
+export RUSTFLAGS="\${RUSTFLAGS} ${rust_target_cpu}"
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set number = 1 %}
+{% set number = 2 %}
 
 package:
   name: microarch-level-split
@@ -28,14 +28,14 @@ outputs:
       description: |
         The meta-package _{{ family }}-microarch-level enforces the microarchitecture in the
         user system.
-    
+
         Note that a user would need the archspec conda package installed
         in the base environment where conda/mamba is run from.
 
         See {{ family }}-microarch-level for using this in conda recipes
       license: BSD-3-Clause
       license_file: LICENSE.txt
-    
+
   - name: {{ family }}-microarch-level
     script: install_scripts.sh
     build:
@@ -55,7 +55,7 @@ outputs:
         Use the meta-package {{ family }}-microarch-level in requirements/build in conda
         recipes to set up the compiler flags and set up the virtual package
         requirements in the run requirements.
-    
+
         When building packages on CI, level=4 will not be guaranteed, so
         you can only use level<=3 to build.
 


### PR DESCRIPTION
Adds the appropriate target-cpu argument for rustc.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
https://rust-lang.github.io/packed_simd/perf-guide/target-feature/rustflags.html

My understanding is the the target-cpu optimization for rust is whatever is available from LLVM. I don't think LLVM offers optimizations for powerpc, or maybe I just don't recognize the name of target that would be used.